### PR TITLE
Move instance between security groups

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
@@ -99,8 +99,7 @@ public class UpdateVMCmd extends BaseCustomIdCmd {
                type = CommandType.LIST,
                collectionType = CommandType.UUID,
                entityType = SecurityGroupResponse.class,
-               description = "list of security group ids to be applied on the virtual machine. " +
-                   "In case no security groups are provided the VM is part of the default security group.")
+               description = "list of security group ids to be applied on the virtual machine.")
     private List<Long> securityGroupIdList;
 
     /////////////////////////////////////////////////////

--- a/api/src/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
@@ -29,6 +29,7 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.GuestOSResponse;
+import org.apache.cloudstack.api.response.SecurityGroupResponse;
 import org.apache.cloudstack.api.response.UserVmResponse;
 import org.apache.cloudstack.context.CallContext;
 
@@ -40,6 +41,7 @@ import com.cloud.vm.VirtualMachine;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.List;
 
 @APICommand(name = "updateVirtualMachine", description="Updates properties of a virtual machine. The VM has to be stopped and restarted for the " +
         "new properties to take effect. UpdateVirtualMachine does not first check whether the VM is stopped. " +
@@ -93,6 +95,14 @@ public class UpdateVMCmd extends BaseCustomIdCmd {
     @Parameter(name = ApiConstants.DETAILS, type = CommandType.MAP, description = "Details in key/value pairs.")
     protected Map details;
 
+    @Parameter(name = ApiConstants.SECURITY_GROUP_IDS,
+               type = CommandType.LIST,
+               collectionType = CommandType.UUID,
+               entityType = SecurityGroupResponse.class,
+               description = "list of security group ids to be applied on the virtual machine. " +
+                   "In case no security groups are provided the VM is part of the default security group.")
+    private List<Long> securityGroupIdList;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -136,6 +146,10 @@ public class UpdateVMCmd extends BaseCustomIdCmd {
 
         Collection paramsCollection = this.details.values();
         return (Map) (paramsCollection.toArray())[0];
+    }
+
+    public List<Long> getSecurityGroupIdList() {
+        return securityGroupIdList;
     }
 
     /////////////////////////////////////////////////////

--- a/server/src/com/cloud/vm/UserVmManager.java
+++ b/server/src/com/cloud/vm/UserVmManager.java
@@ -100,7 +100,7 @@ public interface UserVmManager extends UserVmService {
     void collectVmDiskStatistics(UserVmVO userVm);
 
     UserVm updateVirtualMachine(long id, String displayName, String group, Boolean ha, Boolean isDisplayVmEnabled, Long osTypeId, String userData,
-        Boolean isDynamicallyScalable, HTTPMethod httpMethod, String customId, String hostName) throws ResourceUnavailableException, InsufficientCapacityException;
+        Boolean isDynamicallyScalable, HTTPMethod httpMethod, String customId, String hostName, List<Long> securityGroupIdList) throws ResourceUnavailableException, InsufficientCapacityException;
 
     //the validateCustomParameters, save and remove CustomOfferingDetils functions can be removed from the interface once we can
     //find a common place for all the scaling and upgrading code of both user and systemvms.

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -2022,10 +2022,14 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (securityGroupIdList != null && isVmWare) {
             throw new InvalidParameterValueException("Security group feature is not supported for vmWare hypervisor");
         } else if (securityGroupIdList != null && _networkModel.isSecurityGroupSupportedInNetwork(defaultNetwork) && _networkModel.canAddDefaultSecurityGroup()) {
-            // Remove instance from security groups
-            _securityGroupMgr.removeInstanceFromGroups(id);
-            // Add instance in provided groups
-            _securityGroupMgr.addInstanceToGroups(id, securityGroupIdList);
+            if (vm.getState() == State.Stopped) {
+                // Remove instance from security groups
+                _securityGroupMgr.removeInstanceFromGroups(id);
+                // Add instance in provided groups
+                _securityGroupMgr.addInstanceToGroups(id, securityGroupIdList);
+            } else {
+                throw new InvalidParameterValueException("Virtual machine must be stopped prior to update security groups ");
+            }
         }
 
         if (hostName != null) {

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -1864,6 +1864,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         String hostName = cmd.getHostName();
         Map details = cmd.getDetails();
         Account caller = CallContext.current().getCallingAccount();
+        List<Long> securityGroupIdList = cmd.getSecurityGroupIdList();
 
         // Input validation and permission checks
         UserVmVO vmInstance = _vmDao.findById(id.longValue());
@@ -1907,7 +1908,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             _vmDao.saveDetails(vmInstance);
         }
 
-        return updateVirtualMachine(id, displayName, group, ha, isDisplayVm, osTypeId, userData, isDynamicallyScalable, cmd.getHttpMethod(), cmd.getCustomId(), hostName);
+        return updateVirtualMachine(id, displayName, group, ha, isDisplayVm, osTypeId, userData, isDynamicallyScalable, cmd.getHttpMethod(), cmd.getCustomId(), hostName, securityGroupIdList);
     }
 
     private void saveUsageEvent(UserVmVO vm) {
@@ -1957,7 +1958,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     @Override
     public UserVm updateVirtualMachine(long id, String displayName, String group, Boolean ha, Boolean isDisplayVmEnabled, Long osTypeId, String userData,
-            Boolean isDynamicallyScalable, HTTPMethod httpMethod, String customId, String hostName) throws ResourceUnavailableException, InsufficientCapacityException {
+            Boolean isDynamicallyScalable, HTTPMethod httpMethod, String customId, String hostName, List<Long> securityGroupIdList) throws ResourceUnavailableException, InsufficientCapacityException {
         UserVmVO vm = _vmDao.findById(id);
         if (vm == null) {
             throw new CloudRuntimeException("Unable to find virual machine with id " + id);
@@ -2010,6 +2011,21 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         if (isDynamicallyScalable == null) {
             isDynamicallyScalable = vm.isDynamicallyScalable();
+        }
+
+        // Get default guest network in Basic zone
+        DataCenterVO zone = _dcDao.findById(vm.getDataCenterId());
+        Network defaultNetwork = _networkModel.getExclusiveGuestNetwork(zone.getId());
+
+        boolean isVmWare = (vm.getHypervisorType() == HypervisorType.VMware);
+
+        if (securityGroupIdList != null && isVmWare) {
+            throw new InvalidParameterValueException("Security group feature is not supported for vmWare hypervisor");
+        } else if (securityGroupIdList != null && _networkModel.isSecurityGroupSupportedInNetwork(defaultNetwork) && _networkModel.canAddDefaultSecurityGroup()) {
+            // Remove instance from security groups
+            _securityGroupMgr.removeInstanceFromGroups(id);
+            // Add instance in provided groups
+            _securityGroupMgr.addInstanceToGroups(id, securityGroupIdList);
         }
 
         if (hostName != null) {


### PR DESCRIPTION
This allows changing the security groups of an instance.
Instances must be stopped for this to happen.