### PR TITLE
Revert Snapshots & Better Kafka Events

### DIFF
--- a/api/src/com/cloud/storage/Volume.java
+++ b/api/src/com/cloud/storage/Volume.java
@@ -38,6 +38,7 @@ public interface Volume extends ControlledEntity, Identity, InternalIdentity, Ba
         Ready("The volume is ready to be used."),
         Migrating("The volume is migrating to other storage pool"),
         Snapshotting("There is a snapshot created on this volume, not backed up to secondary storage yet"),
+        RevertSnapshotting("There is a snapshot created on this volume, the volume is being reverting from snapshot"),
         Resizing("The volume is being resized"),
         Expunging("The volume is being expunging"),
         Expunged("The volume is being expunging"),
@@ -97,6 +98,9 @@ public interface Volume extends ControlledEntity, Identity, InternalIdentity, Ba
             s_fsm.addTransition(Expunged, Event.ExpungingRequested, Expunged);
             s_fsm.addTransition(Expunged, Event.OperationSucceeded, Expunged);
             s_fsm.addTransition(Expunged, Event.OperationFailed, Expunged);
+            s_fsm.addTransition(Ready, Event.RevertSnapshotRequested, RevertSnapshotting);
+            s_fsm.addTransition(RevertSnapshotting, Event.OperationSucceeded, Ready);
+            s_fsm.addTransition(RevertSnapshotting, Event.OperationFailed, Ready);
         }
     }
 
@@ -111,6 +115,7 @@ public interface Volume extends ControlledEntity, Identity, InternalIdentity, Ba
         UploadRequested,
         MigrationRequested,
         SnapshotRequested,
+        RevertSnapshotRequested,
         DestroyRequested,
         ExpungingRequested,
         ResizeRequested;

--- a/api/src/org/apache/cloudstack/api/command/user/snapshot/RevertSnapshotCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/snapshot/RevertSnapshotCmd.java
@@ -36,7 +36,7 @@ import com.cloud.event.EventTypes;
 import com.cloud.storage.Snapshot;
 import com.cloud.user.Account;
 
-@APICommand(name = "revertSnapshot", description = "revert a volume snapshot.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
+@APICommand(name = "revertSnapshot", description = "revert a volume snapshot.", responseObject = SuccessResponse.class, entityType = {Snapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RevertSnapshotCmd extends BaseAsyncCmd {
     private static final String s_name = "revertsnapshotresponse";
@@ -91,7 +91,6 @@ public class RevertSnapshotCmd extends BaseAsyncCmd {
         boolean result = _snapshotService.revertSnapshot(getId());
         if (result) {
             SuccessResponse response = new SuccessResponse(getCommandName());
-            response.setResponseName(getCommandName());
             setResponseObject(response);
         } else {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to revert snapshot");

--- a/core/src/com/cloud/agent/api/HostStatsEntry.java
+++ b/core/src/com/cloud/agent/api/HostStatsEntry.java
@@ -98,7 +98,7 @@ public class HostStatsEntry implements HostStats {
 
     @Override
     public double getUsedMemory() {
-        return (totalMemoryKBs - freeMemoryKBs);
+        return (totalMemoryKBs - freeMemoryKBs) * 1024;
     }
 
     @Override

--- a/core/src/org/apache/cloudstack/storage/command/RevertSnapshotCommand.java
+++ b/core/src/org/apache/cloudstack/storage/command/RevertSnapshotCommand.java
@@ -16,9 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.cloudstack.engine.subsystem.api.storage;
+package org.apache.cloudstack.storage.command;
 
-public enum DataStoreCapabilities {
-    VOLUME_SNAPSHOT_QUIESCEVM,
-    STORAGE_SYSTEM_SNAPSHOT // indicates to the StorageSystemSnapshotStrategy that this driver takes snapshots on its own system
+import com.cloud.agent.api.Command;
+import org.apache.cloudstack.storage.to.SnapshotObjectTO;
+
+public final class RevertSnapshotCommand extends Command implements StorageSubSystemCommand {
+    private SnapshotObjectTO data;
+    private boolean _executeInSequence = false;
+
+    public RevertSnapshotCommand(SnapshotObjectTO data) {
+        super();
+        this.data = data;
+    }
+
+    protected RevertSnapshotCommand() {
+        super();
+    }
+
+    public SnapshotObjectTO getData() {
+        return this.data;
+    }
+
+    @Override
+    public void setExecuteInSequence(final boolean executeInSequence) {
+        _executeInSequence = executeInSequence;
+    }
+
+    public boolean executeInSequence() {
+        return _executeInSequence;
+    }
 }

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/PrimaryDataStoreDriver.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/PrimaryDataStoreDriver.java
@@ -36,5 +36,5 @@ public interface PrimaryDataStoreDriver extends DataStoreDriver {
 
     public void takeSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CreateCmdResult> callback);
 
-    public void revertSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback);
+    public void revertSnapshot(SnapshotInfo snapshotOnImageStore, SnapshotInfo snapshotOnPrimaryStore, AsyncCompletionCallback<CommandResult> callback);
 }

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotService.java
@@ -24,7 +24,7 @@ public interface SnapshotService {
 
     boolean deleteSnapshot(SnapshotInfo snapshot);
 
-    boolean revertSnapshot(Long snapshotId);
+    boolean revertSnapshot(SnapshotInfo snapshot);
 
     void syncVolumeSnapshotsToRegionStore(long volumeId, DataStore store);
 }

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotStrategy.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotStrategy.java
@@ -29,7 +29,7 @@ public interface SnapshotStrategy {
 
     boolean deleteSnapshot(Long snapshotId);
 
-    boolean revertSnapshot(Long snapshotId);
+    boolean revertSnapshot(SnapshotInfo snapshot);
 
     StrategyPriority canHandle(Snapshot snapshot, SnapshotOperation op);
 }

--- a/engine/components-api/src/com/cloud/event/UsageEventUtils.java
+++ b/engine/components-api/src/com/cloud/event/UsageEventUtils.java
@@ -67,7 +67,16 @@ public class UsageEventUtils {
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, Long offeringId, Long templateId,
         Long size, String entityType, String entityUUID) {
         saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName, offeringId, templateId, size);
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+        eventDescription.put("resourcename", resourceName);
+        if (offeringId != null) {
+                eventDescription.put("offeringid", offeringId.toString());
+        }
+        if (templateId != null) {
+                eventDescription.put("templateid", templateId.toString());
+        }
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, Long offeringId, Long templateId,
@@ -75,32 +84,71 @@ public class UsageEventUtils {
         if(displayResource){
             saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName, offeringId, templateId, size);
         }
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+        eventDescription.put("resourcename", resourceName);
+        if (offeringId != null) {
+                eventDescription.put("offeringid", offeringId.toString());
+        }
+        if (templateId != null) {
+                eventDescription.put("templateid", templateId.toString());
+        }
+        if (size != null) {
+                eventDescription.put("size", size.toString());
+        }
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
 
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, Long offeringId, Long templateId,
         Long size, Long virtualSize, String entityType, String entityUUID) {
         saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName, offeringId, templateId, size, virtualSize);
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+        eventDescription.put("resourcename", resourceName);
+        if (offeringId != null) {
+                eventDescription.put("offeringid", offeringId.toString());
+        }
+        if (templateId != null) {
+                eventDescription.put("templateid", templateId.toString());
+        }
+        if (size != null) {
+                eventDescription.put("size", size.toString());
+        }
+        if (virtualSize != null) {
+                eventDescription.put("virtualsize", virtualSize.toString());
+        }
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, String entityType, String entityUUID) {
         saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName);
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+        eventDescription.put("resourcename", resourceName);
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, String entityType, String entityUUID, boolean diplayResource) {
         if (diplayResource){
             saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName);
-            publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+            Map<String, String> eventDescription = new HashMap<String, String>();
+            eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+            eventDescription.put("resourcename", resourceName);
+            publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
         }
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long ipAddressId, String ipAddress, boolean isSourceNat, String guestType,
         boolean isSystem, String entityType, String entityUUID) {
         saveUsageEvent(usageType, accountId, zoneId, ipAddressId, ipAddress, isSourceNat, guestType, isSystem);
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("ipaddressid", Long.valueOf(ipAddressId).toString());
+        eventDescription.put("ipaddress", ipAddress);
+        eventDescription.put("issourcenat", Boolean.valueOf(isSourceNat).toString());
+        eventDescription.put("guesttype", guestType);
+        eventDescription.put("issystem", Boolean.valueOf(isSystem).toString());
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, Long offeringId, Long templateId,
@@ -108,13 +156,26 @@ public class UsageEventUtils {
         if(displayResource){
             saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName, offeringId, templateId, resourceType);
         }
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+        eventDescription.put("resourcename", resourceName);
+        if (offeringId != null) {
+                eventDescription.put("offeringid", offeringId.toString());
+        }
+        if (templateId != null) {
+                eventDescription.put("templateid", templateId.toString());
+        }
+        eventDescription.put("resourcetype", resourceType);
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
 
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long vmId, long securityGroupId, String entityType, String entityUUID) {
         saveUsageEvent(usageType, accountId, zoneId, vmId, securityGroupId);
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.put("vmid", Long.valueOf(vmId).toString());
+        eventDescription.put("securitygroupid", Long.valueOf(securityGroupId).toString());
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
     }
 
     public static void publishUsageEvent(String usageType, long accountId, long zoneId, long resourceId, String resourceName, Long offeringId, Long templateId,
@@ -122,7 +183,18 @@ public class UsageEventUtils {
         if(displayResource){
             saveUsageEvent(usageType, accountId, zoneId, resourceId, resourceName, offeringId, templateId, resourceType, details);
         }
-        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID);
+        Map<String, String> eventDescription = new HashMap<String, String>();
+        eventDescription.putAll(details);
+        eventDescription.put("resourceid", Long.valueOf(resourceId).toString());
+        eventDescription.put("resourcename", resourceName);
+        if (offeringId != null) {
+                eventDescription.put("offeringid", offeringId.toString());
+        }
+        if (templateId != null) {
+                eventDescription.put("templateid", templateId.toString());
+        }
+        eventDescription.put("resourcetype", resourceType);
+        publishUsageEvent(usageType, accountId, zoneId, entityType, entityUUID, eventDescription);
 
     }
 
@@ -160,7 +232,8 @@ public class UsageEventUtils {
         s_usageEventDao.persist(new UsageEventVO(usageType, accountId, zoneId, vmId, securityGroupId));
     }
 
-    private static void publishUsageEvent(String usageEventType, Long accountId, Long zoneId, String resourceType, String resourceUUID) {
+    private static void publishUsageEvent(String usageEventType, Long accountId, Long zoneId, String resourceType, String resourceUUID, Map<String, String> eventDescription) {
+        assert(eventDescription != null);
 
         try {
             s_eventBus = ComponentContext.getComponent(EventBus.class);
@@ -182,12 +255,12 @@ public class UsageEventUtils {
 
         Event event = new Event(Name, EventCategory.USAGE_EVENT.getName(), usageEventType, resourceType, resourceUUID);
 
-        Map<String, String> eventDescription = new HashMap<String, String>();
         eventDescription.put("account", account.getUuid());
         eventDescription.put("zone", zoneUuid);
         eventDescription.put("event", usageEventType);
         eventDescription.put("resource", resourceType);
         eventDescription.put("id", resourceUUID);
+        eventDescription.put("version", "1");
 
         String eventDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(new Date());
         eventDescription.put("eventDateTime", eventDate);

--- a/engine/schema/src/org/apache/cloudstack/storage/datastore/db/SnapshotDataStoreDao.java
+++ b/engine/schema/src/org/apache/cloudstack/storage/datastore/db/SnapshotDataStoreDao.java
@@ -40,6 +40,8 @@ public interface SnapshotDataStoreDao extends GenericDao<SnapshotDataStoreVO, Lo
 
     SnapshotDataStoreVO findBySnapshot(long snapshotId, DataStoreRole role);
 
+    SnapshotDataStoreVO findByVolume(long volumeId, DataStoreRole role);
+
     List<SnapshotDataStoreVO> listDestroyed(long storeId);
 
     List<SnapshotDataStoreVO> findBySnapshotId(long snapshotId);

--- a/engine/storage/snapshot/resources/META-INF/cloudstack/storage/spring-engine-storage-snapshot-storage-context.xml
+++ b/engine/storage/snapshot/resources/META-INF/cloudstack/storage/spring-engine-storage-snapshot-storage-context.xml
@@ -28,7 +28,10 @@
                       >
 
     <bean id="xenserverSnapshotStrategy"
-        class="org.apache.cloudstack.storage.snapshot.XenserverSnapshotStrategy" />
+          class="org.apache.cloudstack.storage.snapshot.XenserverSnapshotStrategy" />
+
+    <bean id="storageSystemSnapshotStrategy"
+          class="org.apache.cloudstack.storage.snapshot.StorageSystemSnapshotStrategy" />
 
     <bean id="DefaultVMSnapshotStrategy"
         class="org.apache.cloudstack.storage.vmsnapshot.DefaultVMSnapshotStrategy" />

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotDataFactoryImpl.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotDataFactoryImpl.java
@@ -72,7 +72,10 @@ public class SnapshotDataFactoryImpl implements SnapshotDataFactory {
         SnapshotVO snapshot = snapshotDao.findById(snapshotId);
         SnapshotDataStoreVO snapshotStore = snapshotStoreDao.findBySnapshot(snapshotId, role);
         if (snapshotStore == null) {
-            return null;
+            snapshotStore = snapshotStoreDao.findByVolume(snapshot.getVolumeId(), role);
+            if (snapshotStore == null) {
+                return null;
+            }
         }
         DataStore store = storeMgr.getDataStore(snapshotStore.getDataStoreId(), role);
         SnapshotObject so = SnapshotObject.getSnapshotObject(snapshot, store);

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotServiceImpl.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotServiceImpl.java
@@ -403,16 +403,16 @@ public class SnapshotServiceImpl implements SnapshotService {
     }
 
     @Override
-    public boolean revertSnapshot(Long snapshotId) {
-        SnapshotInfo snapshot = _snapshotFactory.getSnapshot(snapshotId, DataStoreRole.Primary);
-        PrimaryDataStore store = (PrimaryDataStore)snapshot.getDataStore();
+    public boolean revertSnapshot(SnapshotInfo snapshot) {
+        SnapshotInfo snapshotOnPrimaryStore = _snapshotFactory.getSnapshot(snapshot.getId(), DataStoreRole.Primary);
+        PrimaryDataStore store = (PrimaryDataStore)snapshotOnPrimaryStore.getDataStore();
 
         AsyncCallFuture<SnapshotResult> future = new AsyncCallFuture<SnapshotResult>();
         RevertSnapshotContext<CommandResult> context = new RevertSnapshotContext<CommandResult>(null, snapshot, future);
         AsyncCallbackDispatcher<SnapshotServiceImpl, CommandResult> caller = AsyncCallbackDispatcher.create(this);
         caller.setCallback(caller.getTarget().revertSnapshotCallback(null, null)).setContext(context);
 
-        ((PrimaryDataStoreDriver)store.getDriver()).revertSnapshot(snapshot, caller);
+        ((PrimaryDataStoreDriver)store.getDriver()).revertSnapshot(snapshot, snapshotOnPrimaryStore, caller);
 
         SnapshotResult result = null;
         try {

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotStrategyBase.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotStrategyBase.java
@@ -37,7 +37,7 @@ public abstract class SnapshotStrategyBase implements SnapshotStrategy {
     }
 
     @Override
-    public boolean revertSnapshot(Long snapshotId) {
-        return snapshotSvr.revertSnapshot(snapshotId);
+    public boolean revertSnapshot(SnapshotInfo snapshot) {
+        return snapshotSvr.revertSnapshot(snapshot);
     }
 }

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/StorageSystemSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/StorageSystemSnapshotStrategy.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.storage.snapshot;
+
+import javax.inject.Inject;
+
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeService;
+import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine.Event;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
+
+
+import com.cloud.agent.AgentManager;
+import com.cloud.host.dao.HostDao;
+import com.cloud.server.ManagementService;
+import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.Snapshot;
+import com.cloud.storage.SnapshotVO;
+import com.cloud.storage.Storage.ImageFormat;
+import com.cloud.storage.StoragePool;
+import com.cloud.storage.StoragePoolStatus;
+import com.cloud.storage.Volume;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.SnapshotDao;
+import com.cloud.storage.dao.SnapshotDetailsDao;
+import com.cloud.storage.dao.VolumeDao;
+import com.cloud.utils.db.DB;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.dao.VMInstanceDao;
+
+@Component
+public class StorageSystemSnapshotStrategy extends SnapshotStrategyBase {
+    private static final Logger s_logger = Logger.getLogger(StorageSystemSnapshotStrategy.class);
+
+    @Inject private AgentManager _agentMgr;
+    @Inject private DataStoreManager _dataStoreMgr;
+    @Inject private HostDao _hostDao;
+    @Inject private ManagementService _mgr;
+    @Inject private PrimaryDataStoreDao _storagePoolDao;
+    @Inject private SnapshotDao _snapshotDao;
+    @Inject private SnapshotDataFactory _snapshotDataFactory;
+    @Inject private SnapshotDataStoreDao _snapshotStoreDao;
+    @Inject private SnapshotDetailsDao _snapshotDetailsDao;
+    @Inject private VMInstanceDao _vmInstanceDao;
+    @Inject private VolumeDao _volumeDao;
+    @Inject private VolumeService _volService;
+
+    @Override
+    public SnapshotInfo backupSnapshot(SnapshotInfo snapshotInfo) {
+        return snapshotInfo;
+    }
+
+    @Override
+    public boolean deleteSnapshot(Long snapshotId) {
+        return false;
+    }
+
+    @Override
+    @DB
+    public SnapshotInfo takeSnapshot(SnapshotInfo snapshotInfo) {
+        return null;
+    }
+
+    @Override
+    public boolean revertSnapshot(SnapshotInfo snapshot) {
+        if (canHandle(snapshot,SnapshotOperation.REVERT) == StrategyPriority.CANT_HANDLE) {
+            throw new UnsupportedOperationException("Reverting not supported. Create a template or volume based on the snapshot instead.");
+        }
+
+        SnapshotVO snapshotVO = _snapshotDao.acquireInLockTable(snapshot.getId());
+        if (snapshotVO == null) {
+            throw new CloudRuntimeException("Failed to get lock on snapshot:" + snapshot.getId());
+        }
+
+        try {
+            VolumeInfo volumeInfo = snapshot.getBaseVolume();
+            StoragePool store = (StoragePool)volumeInfo.getDataStore();
+            if (store != null && store.getStatus() != StoragePoolStatus.Up) {
+                snapshot.processEvent(Event.OperationFailed);
+                throw new CloudRuntimeException("store is not in up state");
+            }
+            volumeInfo.stateTransit(Volume.Event.RevertSnapshotRequested);
+            boolean result = false;
+            try {
+                result =  snapshotSvr.revertSnapshot(snapshot);
+                if (! result) {
+                    s_logger.debug("Failed to revert snapshot: " + snapshot.getId());
+                    throw new CloudRuntimeException("Failed to revert snapshot: " + snapshot.getId());
+                }
+            } finally {
+                if (result) {
+                    volumeInfo.stateTransit(Volume.Event.OperationSucceeded);
+                } else {
+                    volumeInfo.stateTransit(Volume.Event.OperationFailed);
+                }
+            }
+            return result;
+        } finally {
+            if (snapshotVO != null) {
+                _snapshotDao.releaseFromLockTable(snapshot.getId());
+            }
+        }
+    }
+
+
+    @Override
+    public StrategyPriority canHandle(Snapshot snapshot, SnapshotOperation op) {
+        long volumeId = snapshot.getVolumeId();
+        VolumeVO volumeVO = _volumeDao.findById(volumeId);
+
+        long storagePoolId;
+
+        if (volumeVO == null) {
+            SnapshotDataStoreVO snapshotStore = _snapshotStoreDao.findBySnapshot(snapshot.getId(), DataStoreRole.Primary);
+
+            if (snapshotStore != null) {
+                storagePoolId = snapshotStore.getDataStoreId();
+            }
+            else {
+                throw new CloudRuntimeException("Unable to determine the storage pool of the snapshot");
+            }
+        }
+        else {
+            storagePoolId = volumeVO.getPoolId();
+        }
+
+        if (SnapshotOperation.REVERT.equals(op)) {
+            if (volumeVO != null && ImageFormat.QCOW2.equals(volumeVO.getFormat()))
+                return StrategyPriority.DEFAULT;
+            else
+                return StrategyPriority.CANT_HANDLE;
+        }
+
+        return StrategyPriority.CANT_HANDLE;
+    }
+}

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
@@ -260,7 +260,7 @@ public class XenserverSnapshotStrategy extends SnapshotStrategyBase {
     }
 
     @Override
-    public boolean revertSnapshot(Long snapshotId) {
+    public boolean revertSnapshot(SnapshotInfo snapshot) {
         throw new CloudRuntimeException("revert Snapshot is not supported");
     }
 

--- a/engine/storage/src/org/apache/cloudstack/storage/image/db/SnapshotDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/db/SnapshotDataStoreDaoImpl.java
@@ -54,6 +54,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
     private SearchBuilder<SnapshotDataStoreVO> snapshotSearch;
     private SearchBuilder<SnapshotDataStoreVO> storeSnapshotSearch;
     private SearchBuilder<SnapshotDataStoreVO> snapshotIdSearch;
+    private SearchBuilder<SnapshotDataStoreVO> volumeSearch;
 
     private final String parentSearch = "select store_id, store_role, snapshot_id from cloud.snapshot_store_ref where store_id = ? "
         + " and store_role = ? and volume_id = ? and state = 'Ready'" + " order by created DESC " + " limit 1";
@@ -109,6 +110,11 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
         snapshotIdSearch = createSearchBuilder();
         snapshotIdSearch.and("snapshot_id", snapshotIdSearch.entity().getSnapshotId(), SearchCriteria.Op.EQ);
         snapshotIdSearch.done();
+
+        volumeSearch = createSearchBuilder();
+        volumeSearch.and("volume_id", volumeSearch.entity().getVolumeId(), SearchCriteria.Op.EQ);
+        volumeSearch.and("store_role", volumeSearch.entity().getRole(), SearchCriteria.Op.EQ);
+        volumeSearch.done();
 
         return true;
     }
@@ -269,6 +275,14 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
     public SnapshotDataStoreVO findBySnapshot(long snapshotId, DataStoreRole role) {
         SearchCriteria<SnapshotDataStoreVO> sc = snapshotSearch.create();
         sc.setParameters("snapshot_id", snapshotId);
+        sc.setParameters("store_role", role);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public SnapshotDataStoreVO findByVolume(long volumeId, DataStoreRole role) {
+        SearchCriteria<SnapshotDataStoreVO> sc = volumeSearch.create();
+        sc.setParameters("volume_id", volumeId);
         sc.setParameters("store_role", role);
         return findOneBy(sc);
     }

--- a/plugins/storage/volume/cloudbyte/src/org/apache/cloudstack/storage/datastore/driver/ElastistorPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/cloudbyte/src/org/apache/cloudstack/storage/datastore/driver/ElastistorPrimaryDataStoreDriver.java
@@ -90,7 +90,7 @@ public class ElastistorPrimaryDataStoreDriver  extends CloudStackPrimaryDataStor
     }
 
     @Override
-    public void revertSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
+    public void revertSnapshot(SnapshotInfo snapshotOnPrimary, SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
         throw new UnsupportedOperationException();
     }
 

--- a/plugins/storage/volume/default/src/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/default/src/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
@@ -44,6 +44,7 @@ import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.CreateObjectCommand;
 import org.apache.cloudstack.storage.command.DeleteCommand;
+import org.apache.cloudstack.storage.command.RevertSnapshotCommand;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.SnapshotObjectTO;
@@ -309,7 +310,28 @@ public class CloudStackPrimaryDataStoreDriverImpl implements PrimaryDataStoreDri
     }
 
     @Override
-    public void revertSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
+    public void revertSnapshot(SnapshotInfo snapshot, SnapshotInfo snapshotOnPrimaryStore, AsyncCompletionCallback<CommandResult> callback) {
+        SnapshotObjectTO snapshotTO = (SnapshotObjectTO)snapshot.getTO();
+        RevertSnapshotCommand cmd = new RevertSnapshotCommand(snapshotTO);
+
+        CommandResult result = new CommandResult();
+        try {
+            EndPoint ep = epSelector.select(snapshotOnPrimaryStore);
+            if ( ep == null ){
+                String errMsg = "No remote endpoint to send RevertSnapshotCommand, check if host or ssvm is down?";
+                s_logger.error(errMsg);
+                result.setResult(errMsg);
+            } else {
+                Answer answer = ep.sendMessage(cmd);
+                if (answer != null && !answer.getResult()) {
+                    result.setResult(answer.getDetails());
+                }
+            }
+        } catch (Exception ex) {
+            s_logger.debug("Unable to revert snapshot " + snapshot.getId(), ex);
+            result.setResult(ex.toString());
+        }
+        callback.complete(result);
     }
 
     @Override

--- a/plugins/storage/volume/nexenta/src/org/apache/cloudstack/storage/datastore/driver/NexentaPrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/nexenta/src/org/apache/cloudstack/storage/datastore/driver/NexentaPrimaryDataStoreDriver.java
@@ -120,7 +120,7 @@ public class NexentaPrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     public void takeSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CreateCmdResult> callback) {}
 
     @Override
-    public void revertSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {}
+    public void revertSnapshot(SnapshotInfo snapshotOnPrimary, SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {}
 
     @Override
     public void createAsync(DataStore dataStore, DataObject dataObject, AsyncCompletionCallback<CreateCmdResult> callback) {

--- a/plugins/storage/volume/sample/src/org/apache/cloudstack/storage/datastore/driver/SamplePrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/sample/src/org/apache/cloudstack/storage/datastore/driver/SamplePrimaryDataStoreDriverImpl.java
@@ -200,7 +200,7 @@ public class SamplePrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver 
     }
 
     @Override
-    public void revertSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
+    public void revertSnapshot(SnapshotInfo snapshotOnPrimary, SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
     }
 
     @Override

--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/driver/SolidfirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/driver/SolidfirePrimaryDataStoreDriver.java
@@ -825,7 +825,7 @@ public class SolidfirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     }
 
     @Override
-    public void revertSnapshot(SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
+    public void revertSnapshot(SnapshotInfo snapshotOnPrimary, SnapshotInfo snapshot, AsyncCompletionCallback<CommandResult> callback) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Allow revert snapshots. This is essentially a backport of the 4.6 functionality.
EventBus messages are now produced with additional fields to lower the query overhead in consumers.

- [X] Backport revert snapshot logic
- [X] Wire in new component: `StorageSystemSnapshotStrategy`
- [X] Inject implementation for new component
- [X] Add fields to event bus messages
- [X] Version the schema of sent payload