### PR TITLE
debian: don't take version number directly from debian/changelog

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent> 
   <dependencies>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,9 @@ export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+# From Jenkins
+export BUILD_NUMBER
+
 configure: configure-stamp
 configure-stamp:
 	dh_testdir
@@ -154,6 +157,6 @@ binary: install
 	dh_fixperms
 	dh_makeshlibs
 	dh_installdeb
-	dh_gencontrol
+	dh_gencontrol -- -v$(VERSION)-${BUILD_NUMBER:-0}
 	dh_md5sums
 	dh_builddeb

--- a/debian/rules
+++ b/debian/rules
@@ -11,9 +11,6 @@ export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
-# From Jenkins
-export BUILD_NUMBER
-
 configure: configure-stamp
 configure-stamp:
 	dh_testdir
@@ -157,6 +154,6 @@ binary: install
 	dh_fixperms
 	dh_makeshlibs
 	dh_installdeb
-	dh_gencontrol -- -v$(VERSION)-${BUILD_NUMBER:-0}
+	dh_gencontrol -- -v$(VERSION)
 	dh_md5sums
 	dh_builddeb

--- a/developer/pom.xml
+++ b/developer/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/components-api/pom.xml
+++ b/engine/components-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/network/pom.xml
+++ b/engine/network/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/orchestration/pom.xml
+++ b/engine/orchestration/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/service/pom.xml
+++ b/engine/service/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <artifactId>cloud-engine-service</artifactId>
   <packaging>war</packaging>

--- a/engine/storage/cache/pom.xml
+++ b/engine/storage/cache/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/datamotion/pom.xml
+++ b/engine/storage/datamotion/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/image/pom.xml
+++ b/engine/storage/image/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/integration-test/pom.xml
+++ b/engine/storage/integration-test/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-190-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/pom.xml
+++ b/engine/storage/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/snapshot/pom.xml
+++ b/engine/storage/snapshot/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/volume/pom.xml
+++ b/engine/storage/volume/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/cluster/pom.xml
+++ b/framework/cluster/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/config/pom.xml
+++ b/framework/config/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/db/pom.xml
+++ b/framework/db/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/events/pom.xml
+++ b/framework/events/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/ipc/pom.xml
+++ b/framework/ipc/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/jobs/pom.xml
+++ b/framework/jobs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>  
   <dependencies>

--- a/framework/managed-context/pom.xml
+++ b/framework/managed-context/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-maven-standard</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../maven-standard/pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/framework/rest/pom.xml
+++ b/framework/rest/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-framework-rest</artifactId>

--- a/framework/security/pom.xml
+++ b/framework/security/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/spring/lifecycle/pom.xml
+++ b/framework/spring/lifecycle/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-maven-standard</artifactId>
-        <version>4.4.2-exoscale-192-SNAPSHOT</version>
+        <version>4.4.2-exoscale-SNAPSHOT</version>
         <relativePath>../../../maven-standard/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/spring/module/pom.xml
+++ b/framework/spring/module/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-maven-standard</artifactId>
-        <version>4.4.2-exoscale-192-SNAPSHOT</version>
+        <version>4.4.2-exoscale-SNAPSHOT</version>
         <relativePath>../../../maven-standard/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/maven-standard/pom.xml
+++ b/maven-standard/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/acl/static-role-based/pom.xml
+++ b/plugins/acl/static-role-based/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/affinity-group-processors/explicit-dedication/pom.xml
+++ b/plugins/affinity-group-processors/explicit-dedication/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/affinity-group-processors/host-anti-affinity/pom.xml
+++ b/plugins/affinity-group-processors/host-anti-affinity/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/alert-handlers/snmp-alerts/pom.xml
+++ b/plugins/alert-handlers/snmp-alerts/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cloudstack-plugins</artifactId>
     <groupId>org.apache.cloudstack</groupId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/plugins/alert-handlers/syslog-alerts/pom.xml
+++ b/plugins/alert-handlers/syslog-alerts/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cloudstack-plugins</artifactId>
     <groupId>org.apache.cloudstack</groupId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/plugins/api/discovery/pom.xml
+++ b/plugins/api/discovery/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/api/rate-limit/pom.xml
+++ b/plugins/api/rate-limit/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/database/mysql-ha/pom.xml
+++ b/plugins/database/mysql-ha/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-190-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/dedicated-resources/pom.xml
+++ b/plugins/dedicated-resources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/deployment-planners/implicit-dedication/pom.xml
+++ b/plugins/deployment-planners/implicit-dedication/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/deployment-planners/user-concentrated-pod/pom.xml
+++ b/plugins/deployment-planners/user-concentrated-pod/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/deployment-planners/user-dispersing/pom.xml
+++ b/plugins/deployment-planners/user-dispersing/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/event-bus/inmemory/pom.xml
+++ b/plugins/event-bus/inmemory/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/ha-planners/skip-heurestics/pom.xml
+++ b/plugins/ha-planners/skip-heurestics/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/host-allocators/random/pom.xml
+++ b/plugins/host-allocators/random/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <repositories>

--- a/plugins/hypervisors/simulator/pom.xml
+++ b/plugins/hypervisors/simulator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.4.2-exoscale-190-SNAPSHOT</version>
+        <version>4.4.2-exoscale-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-plugin-hypervisor-simulator</artifactId>

--- a/plugins/network-elements/internal-loadbalancer/pom.xml
+++ b/plugins/network-elements/internal-loadbalancer/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/network-elements/ovs/pom.xml
+++ b/plugins/network-elements/ovs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/plugins/storage-allocators/random/pom.xml
+++ b/plugins/storage-allocators/random/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/image/default/pom.xml
+++ b/plugins/storage/image/default/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/default/pom.xml
+++ b/plugins/storage/volume/default/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/user-authenticators/md5/pom.xml
+++ b/plugins/user-authenticators/md5/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/user-authenticators/plain-text/pom.xml
+++ b/plugins/user-authenticators/plain-text/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/user-authenticators/sha256salted/pom.xml
+++ b/plugins/user-authenticators/sha256salted/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.apache.cloudstack</groupId>
   <artifactId>cloudstack</artifactId>
-  <version>4.4.2-exoscale-192-SNAPSHOT</version>
+  <version>4.4.2-exoscale-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache CloudStack</name>
   <description>Apache CloudStack is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1150,6 +1150,10 @@
     </profile>
     <profile>
       <id>exoscale</id>
+      <properties>
+        <timestamp>${maven.build.timestamp}</timestamp>
+        <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -1159,6 +1163,10 @@
               <goals>install</goals>
               <arguments>-Dgpg.skip=true</arguments>
               <useReleaseProfile>false</useReleaseProfile>
+              <tagNameFormat>@{project.version}</tagNameFormat>
+              <developmentVersion>${project.version}</developmentVersion>
+              <autoVersionSubmodules>true</autoVersionSubmodules>
+              <releaseVersion>4.4.2-exoscale-${timestamp}</releaseVersion>
             </configuration>
           </plugin>
         </plugins>

--- a/quickcloud/pom.xml
+++ b/quickcloud/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-maven-standard</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../maven-standard/pom.xml</relativePath>
   </parent>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/services/console-proxy-rdp/rdpconsole/pom.xml
+++ b/services/console-proxy-rdp/rdpconsole/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-services</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/services/console-proxy/pom.xml
+++ b/services/console-proxy/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-services</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/services/console-proxy/server/pom.xml
+++ b/services/console-proxy/server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-console-proxy</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/services/secondary-storage/controller/pom.xml
+++ b/services/secondary-storage/controller/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-secondary-storage</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/services/secondary-storage/pom.xml
+++ b/services/secondary-storage/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-services</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modules>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-secondary-storage</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
     <properties>

--- a/systemvm/pom.xml
+++ b/systemvm/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.4.2-exoscale-192-SNAPSHOT</version>
+        <version>4.4.2-exoscale-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/tools/apidoc/pom.xml
+++ b/tools/apidoc/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-tools</artifactId>
-        <version>4.4.2-exoscale-192-SNAPSHOT</version>
+        <version>4.4.2-exoscale-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -23,7 +23,7 @@
     <name>Apache CloudStack Developer Tools - Checkstyle Configuration</name>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>checkstyle</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <build>
       <plugins>
         <plugin>

--- a/tools/devcloud-kvm/pom.xml
+++ b/tools/devcloud-kvm/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/tools/devcloud/pom.xml
+++ b/tools/devcloud/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/tools/marvin/pom.xml
+++ b/tools/marvin/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.4.2-exoscale-192-SNAPSHOT</version>
+        <version>4.4.2-exoscale-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.4.2-exoscale-192-SNAPSHOT</version>
+    <version>4.4.2-exoscale-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>


### PR DESCRIPTION
Use version from pom.xml and add Jenkins build number.

Untested. Open to discussion. If we need to transition from an old scheme, we can use epoch. @marcaurele @llambiel 