### PR TITLE
KVM live migration with non shared storage

### DIFF
--- a/api/src/com/cloud/vm/DiskProfile.java
+++ b/api/src/com/cloud/vm/DiskProfile.java
@@ -70,6 +70,7 @@ public class DiskProfile {
             offering.isCustomized(),
             null);
         this.hyperType = hyperType;
+        this.path = vol.getPath();
     }
 
     public DiskProfile(DiskProfile dp) {

--- a/engine/api/src/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
@@ -105,6 +105,8 @@ public interface VolumeOrchestrationService {
 
     void prepareForMigration(VirtualMachineProfile vm, DeployDestination dest);
 
+    void confirmMigration(VirtualMachineProfile vm, long srcHostId, long destHostId, boolean migrationSuccess);
+
     void prepare(VirtualMachineProfile vm, DeployDestination dest) throws StorageUnavailableException, InsufficientStorageCapacityException, ConcurrentOperationException;
 
     boolean canVmRestartOnAnotherServer(long vmId);

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataMotionStrategy.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataMotionStrategy.java
@@ -30,10 +30,7 @@ public interface DataMotionStrategy {
 
     StrategyPriority canHandle(Map<VolumeInfo, DataStore> volumeMap, Host srcHost, Host destHost);
 
-    Void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback);
+    void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback);
 
-    Void copyAsync(DataObject srcData, DataObject destData, AsyncCompletionCallback<CopyCommandResult> callback);
-
-    Void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback);
-
+    void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback);
 }

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/VolumeService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/VolumeService.java
@@ -100,4 +100,6 @@ public interface VolumeService {
 
     SnapshotInfo takeSnapshot(VolumeInfo volume);
 
+    boolean deleteVolumeOnDataStore(DataStore store, long volumeId);
+
 }

--- a/engine/orchestration/pom.xml
+++ b/engine/orchestration/pom.xml
@@ -57,13 +57,12 @@
       <artifactId>cloud-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- 
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-server</artifactId>
       <version>${project.version}</version>
     </dependency>
-    -->
+
   </dependencies>
   <build>
     <plugins>

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2203,19 +2203,13 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             try {
                 if (!checkVmOnHost(vm, destHostId)) {
                     s_logger.error("Vm not found on destination host. Unable to complete migration for " + vm);
-                    try {
-                        _agentMgr.send(srcHostId, new Commands(cleanup(vm.getInstanceName())), null);
-                    } catch (AgentUnavailableException e) {
-                        s_logger.error("AgentUnavailableException while cleanup on source host: " + srcHostId);
-                    }
-                    cleanup(vmGuru, new VirtualMachineProfileImpl(vm), work, Event.AgentReportStopped, true);
-                    throw new CloudRuntimeException("VM not found on desintation host. Unable to complete migration for " + vm);
+                } else {
+                    migrated = true;
                 }
             } catch (OperationTimedoutException e) {
                 s_logger.warn("Error while checking the vm " + vm + " is on host " + destHost, e);
             }
 
-            migrated = true;
         } finally {
             if (!migrated) {
                 s_logger.info("Migration was unsuccessful.  Cleaning up: " + vm);
@@ -2224,10 +2218,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                         "Migrate Command failed.  Please check logs.");
                 try {
                     _networkMgr.rollbackNicForMigration(vmSrc, profile);
-//                    _agentMgr.send(destHostId, new Commands(cleanup(vm.getInstanceName())), null);
                     stateTransitTo(vm, Event.OperationFailed, srcHostId);
-//                } catch (AgentUnavailableException e) {
-//                    s_logger.warn("Looks like the destination Host is unavailable for cleanup.", e);
                 } catch (NoTransitionException e) {
                     s_logger.error("Error while transitioning vm from migrating to running state.", e);
                 }

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2216,6 +2216,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 _alertMgr.sendAlert(alertType, srcHost.getDataCenterId(), srcHost.getPodId(),
                         "Unable to migrate vm " + vm.getInstanceName() + " from host " + srcHost.getName() + " in zone " + dc.getName() + " and pod " + dc.getName(),
                         "Migrate Command failed.  Please check logs.");
+                vm.setHostId(srcHostId);
+                _vmDao.update(vm.getId(), vm);
                 try {
                     _networkMgr.rollbackNicForMigration(vmSrc, profile);
                     stateTransitTo(vm, Event.OperationFailed, srcHostId);

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -997,6 +997,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
             s_logger.debug("Preparing " + vols.size() + " volumes for " + vm);
         }
 
+
+
         for (VolumeVO vol : vols) {
             DataTO volTO = volFactory.getVolume(vol.getId()).getTO();
             DiskTO disk = new DiskTO(volTO, vol.getDeviceId(), vol.getPath(), vol.getVolumeType());
@@ -1011,7 +1013,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
             if (vm.getType() == VirtualMachine.Type.User && vol.getVolumeType().equals(Type.ROOT)) {
                 VMTemplateVO vmTemplate = _tmpltDao.findById(vol.getTemplateId());
                 StoragePool destStoragePool = storageManager.findLocalStorageOnHost(dest.getHost().getId());
-                _tmpltMgr.prepareTemplateForCreate(vmTemplate, destStoragePool);
+                StoragePool destDataStore = (StoragePool)dataStoreMgr.getDataStore(destStoragePool.getId(), DataStoreRole.Primary);
+                _tmpltMgr.prepareTemplateForCreate(vmTemplate, destDataStore);
             }
         }
 

--- a/engine/schema/src/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
+++ b/engine/schema/src/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
@@ -70,7 +70,7 @@ public class HypervisorCapabilitiesDaoImpl extends GenericDaoBase<HypervisorCapa
     public HypervisorCapabilitiesVO findByHypervisorTypeAndVersion(HypervisorType hypervisorType, String hypervisorVersion) {
         SearchCriteria<HypervisorCapabilitiesVO> sc = HypervisorTypeAndVersionSearch.create();
         sc.setParameters("hypervisorType", hypervisorType);
-        sc.setParameters("hypervisorVersion", hypervisorVersion);
+        sc.setParameters("hypervisorVersion", (hypervisorVersion == null ? DEFAULT_VERSION : hypervisorVersion));
         return findOneBy(sc);
     }
 

--- a/engine/storage/datamotion/resources/META-INF/cloudstack/storage/spring-engine-storage-datamotion-storage-context.xml
+++ b/engine/storage/datamotion/resources/META-INF/cloudstack/storage/spring-engine-storage-datamotion-storage-context.xml
@@ -28,4 +28,6 @@
                       >
     <bean id="ancientDataMotionStrategy"
         class="org.apache.cloudstack.storage.motion.AncientDataMotionStrategy" />
+    <bean id="kvmStorageMotionStrategy"
+          class="org.apache.cloudstack.storage.motion.KVMStorageMotionStrategy" />
 </beans>

--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -23,9 +23,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
 import org.apache.cloudstack.engine.subsystem.api.storage.ClusterScope;
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataMotionStrategy;
@@ -41,7 +38,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.StorageAction;
 import org.apache.cloudstack.engine.subsystem.api.storage.StorageCacheManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
-import org.apache.cloudstack.engine.subsystem.api.storage.TemplateInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
 import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
@@ -49,6 +45,8 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.RemoteHostEndPoint;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.image.datastore.ImageStoreEntity;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.storage.MigrateVolumeAnswer;
@@ -61,9 +59,9 @@ import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.configuration.Config;
 import com.cloud.host.Host;
 import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.VolumeVO;
-import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.utils.NumbersUtil;
 import com.cloud.utils.db.DB;
@@ -99,22 +97,14 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
         DataStoreTO srcStoreTO = srcTO.getDataStore();
 
         if (srcStoreTO instanceof NfsTO || srcStoreTO.getRole() == DataStoreRole.ImageCache) {
-            //||
-            //    (srcStoreTO instanceof PrimaryDataStoreTO && ((PrimaryDataStoreTO)srcStoreTO).getPoolType() == StoragePoolType.NetworkFilesystem)) {
             return false;
         }
-
         DataTO destTO = destData.getTO();
         DataStoreTO destStoreTO = destTO.getDataStore();
 
         if (destStoreTO instanceof NfsTO || destStoreTO.getRole() == DataStoreRole.ImageCache) {
             return false;
         }
-
-        if (srcData.getType() == DataObjectType.TEMPLATE) {
-            TemplateInfo template = (TemplateInfo)srcData;
-        }
-
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("needCacheStorage true, dest at " + destTO.getPath() + " dest role " + destStoreTO.getRole().toString() + srcTO.getPath() + " src role " +
                 srcStoreTO.getRole().toString());
@@ -422,7 +412,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
 
     // Note: destHost is currently only used if the copyObject method is invoked
     @Override
-    public Void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+    public void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         Answer answer = null;
         String errMsg = null;
         try {
@@ -458,12 +448,6 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
         CopyCommandResult result = new CopyCommandResult(null, answer);
         result.setResult(errMsg);
         callback.complete(result);
-        return null;
-    }
-
-    @Override
-    public Void copyAsync(DataObject srcData, DataObject destData, AsyncCompletionCallback<CopyCommandResult> callback) {
-        return copyAsync(srcData, destData, null, callback);
     }
 
     @DB
@@ -562,11 +546,9 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
     }
 
     @Override
-    public Void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+    public void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         CopyCommandResult result = new CopyCommandResult(null, null);
         result.setResult("Unsupported operation requested for copying data.");
         callback.complete(result);
-
-        return null;
     }
 }

--- a/engine/storage/integration-test/test/org/apache/cloudstack/storage/test/MockStorageMotionStrategy.java
+++ b/engine/storage/integration-test/test/org/apache/cloudstack/storage/test/MockStorageMotionStrategy.java
@@ -19,25 +19,17 @@
 package org.apache.cloudstack.storage.test;
 
 import java.util.Map;
-import java.util.UUID;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataMotionStrategy;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
-import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
-import org.apache.cloudstack.storage.command.CopyCmdAnswer;
-import org.apache.cloudstack.storage.to.SnapshotObjectTO;
-import org.apache.cloudstack.storage.to.TemplateObjectTO;
 
-import com.cloud.agent.api.to.DataObjectType;
-import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.host.Host;
-import com.cloud.storage.Storage;
 
 public class MockStorageMotionStrategy implements DataMotionStrategy {
 
@@ -58,46 +50,13 @@ public class MockStorageMotionStrategy implements DataMotionStrategy {
     }
 
     @Override
-    public Void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+    public void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Void copyAsync(DataObject srcData, DataObject destData, AsyncCompletionCallback<CopyCommandResult> callback) {
-        CopyCmdAnswer answer = null;
-        DataTO data = null;
-        if (!success) {
-            CopyCommandResult result = new CopyCommandResult(null, null);
-            result.setResult("Failed");
-            callback.complete(result);
-        }
-        if (destData.getType() == DataObjectType.SNAPSHOT) {
-            SnapshotInfo srcSnapshot = (SnapshotInfo)srcData;
-
-            SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
-            newSnapshot.setPath(UUID.randomUUID().toString());
-            if (srcSnapshot.getParent() != null) {
-                newSnapshot.setParentSnapshotPath(srcSnapshot.getParent().getPath());
-            }
-            data = newSnapshot;
-        } else if (destData.getType() == DataObjectType.TEMPLATE) {
-            TemplateObjectTO newTemplate = new TemplateObjectTO();
-            newTemplate.setPath(UUID.randomUUID().toString());
-            newTemplate.setFormat(Storage.ImageFormat.QCOW2);
-            newTemplate.setSize(10L);
-            newTemplate.setPhysicalSize(10L);
-            data = newTemplate;
-        }
-        answer = new CopyCmdAnswer(data);
-        CopyCommandResult result = new CopyCommandResult("something", answer);
-        callback.complete(result);
-        return null;
-    }
-
-    @Override
-    public Void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+    public void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         CopyCommandResult result = new CopyCommandResult("something", null);
         callback.complete(result);
-        return null;
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3087,7 +3087,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
         }
 
-        String result = executeMigrationWithFlags(vm.getName(), cmd.getTargetHost(), (1 << 0)|(1 << 1)|(1 << 6)|(1 << 8)|(1 << 12)|(1 << 13));
+        String result = executeMigrationWithFlags(vm.getName(), cmd.getTargetHost(), (1 << 0)|(1 << 2)|(1 << 7)|(1 << 8)|(1 << 12)|(1 << 13));
 
         s_logger.debug("executeMigrationWithFlags result is: " + result);
 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3176,7 +3176,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 migrationDestinationHost = destHost;
             }
 
-            s_logger.info("Initiating live migration of instance " + vmName + " to destination host " + migrationDestinationHost);
+            s_logger.info("Initiating live migration of instance " + vmName + " to destination host " + migrationDestinationHost + " with flags " + flags);
             dconn = new Connect(_libvirtConnectionProtocol + migrationDestinationHost + "/system");
 
             //run migration in thread so we can monitor it

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3181,7 +3181,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             //run migration in thread so we can monitor it
             ExecutorService executor = Executors.newFixedThreadPool(1);
-            Callable<Domain> worker = new MigrateKVMAsync(dm, dconn, xmlDesc, vmName, migrationDestinationHost, flags, _migrateSpeed);
+            Callable<Domain> worker = new MigrateKVMAsync(dm, dconn, xmlDesc, vmName, flags, _migrateSpeed);
             Future<Domain> migrateThread = executor.submit(worker);
             executor.shutdown();
             long sleeptime = 0;

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3176,10 +3176,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 migrationDestinationHost = destHost;
             }
 
+            s_logger.info("Initiating live migration of instance " + vmName + " to destination host " + migrationDestinationHost);
             dconn = new Connect(_libvirtConnectionProtocol + migrationDestinationHost + "/system");
 
             //run migration in thread so we can monitor it
-            s_logger.info("Live migration of instance " + vmName + " initiated to destination host " + migrationDestinationHost);
             ExecutorService executor = Executors.newFixedThreadPool(1);
             Callable<Domain> worker = new MigrateKVMAsync(dm, dconn, xmlDesc, vmName, migrationDestinationHost, flags, _migrateSpeed);
             Future<Domain> migrateThread = executor.submit(worker);

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3089,21 +3089,16 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             DataTO data = disk.getData();
             if (data instanceof VolumeObjectTO) {
                 volumes.add((VolumeObjectTO) data);
-                s_logger.debug("Adding volume TO object: " + ((VolumeObjectTO) data).getUuid());
             }
         }
 
         String result = executeMigrationWithFlags(vm.getName(), cmd.getTargetHost(), (1 << 0)|(1 << 1)|(1 << 2)|(1 << 7)|(1 << 8)|(1 << 12)|(1 << 13));
-
-        s_logger.debug("executeMigrationWithFlags result is: " + result);
 
         return new MigrateWithStorageAnswer(cmd, volumes);
     }
 
     private Answer execute(MigrateCommand cmd) {
         String result = executeMigrationWithFlags(cmd.getVmName(), cmd.getDestinationIp(), 1L);
-
-        s_logger.debug("executeMigrationWithFlags result is: " + result);
 
         return new MigrateAnswer(cmd, result == null, result, null);
     }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
@@ -1,0 +1,37 @@
+package com.cloud.hypervisor.kvm.resource;
+
+import org.libvirt.Connect;
+import org.libvirt.Domain;
+import org.libvirt.LibvirtException;
+
+import java.util.concurrent.Callable;
+
+public class MigrateKVMAsync implements Callable<Domain> {
+    Domain dm = null;
+    Connect dconn = null;
+    String dxml = "";
+    String vmName = "";
+    String destIp = "";
+    long flags = 0L;
+    int migrationSpeed = 0;
+
+    MigrateKVMAsync(Domain dm, Connect dconn, String dxml, String vmName, String destIp, long flags, int migrationSpeed) {
+        this.dm = dm;
+        this.dconn = dconn;
+        this.dxml = dxml;
+        this.vmName = vmName;
+        this.destIp = destIp;
+        this.flags = flags;
+        this.migrationSpeed = migrationSpeed;
+    }
+
+    @Override
+    public Domain call() throws LibvirtException {
+        // set compression flag for migration if libvirt version supports it
+        if (dconn.getLibVirVersion() < 1003000) {
+            flags = flags | (1 << 11);
+        }
+        return dm.migrate(dconn, flags, dxml, vmName, null, migrationSpeed);
+    }
+}
+

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
@@ -25,10 +25,6 @@ public class MigrateKVMAsync implements Callable<Domain> {
 
     @Override
     public Domain call() throws LibvirtException {
-        // For version of libvirt that don't support compression, remove the flag
-        if (dconn.getLibVirVersion() < 1003000) {
-            flags = flags & (0 << 11);
-        }
         return dm.migrate(dconn, flags, dxml, vmName, null, migrationSpeed);
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
@@ -28,9 +28,9 @@ public class MigrateKVMAsync implements Callable<Domain> {
     @Override
     public Domain call() throws LibvirtException {
         // set compression flag for migration if libvirt version supports it
-        if (dconn.getLibVirVersion() < 1003000) {
-            flags = flags | (1 << 11);
-        }
+//        if (dconn.getLibVirVersion() < 1003000) {
+//            flags = flags | (1 << 11);
+//        }
         return dm.migrate(dconn, flags, dxml, vmName, null, migrationSpeed);
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/MigrateKVMAsync.java
@@ -11,26 +11,24 @@ public class MigrateKVMAsync implements Callable<Domain> {
     Connect dconn = null;
     String dxml = "";
     String vmName = "";
-    String destIp = "";
     long flags = 0L;
     int migrationSpeed = 0;
 
-    MigrateKVMAsync(Domain dm, Connect dconn, String dxml, String vmName, String destIp, long flags, int migrationSpeed) {
+    MigrateKVMAsync(Domain dm, Connect dconn, String dxml, String vmName, long flags, int migrationSpeed) {
         this.dm = dm;
         this.dconn = dconn;
         this.dxml = dxml;
         this.vmName = vmName;
-        this.destIp = destIp;
         this.flags = flags;
         this.migrationSpeed = migrationSpeed;
     }
 
     @Override
     public Domain call() throws LibvirtException {
-        // set compression flag for migration if libvirt version supports it
-//        if (dconn.getLibVirVersion() < 1003000) {
-//            flags = flags | (1 << 11);
-//        }
+        // For version of libvirt that don't support compression, remove the flag
+        if (dconn.getLibVirVersion() < 1003000) {
+            flags = flags & (0 << 11);
+        }
         return dm.migrate(dconn, flags, dxml, vmName, null, migrationSpeed);
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/motion/KVMStorageMotionStrategy.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/motion/KVMStorageMotionStrategy.java
@@ -1,0 +1,162 @@
+package com.cloud.hypervisor.kvm.storage.motion;
+
+
+import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.MigrateWithStorageAnswer;
+import com.cloud.agent.api.MigrateWithStorageCommand;
+import com.cloud.agent.api.to.StorageFilerTO;
+import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.agent.api.to.VolumeTO;
+import com.cloud.exception.AgentUnavailableException;
+import com.cloud.exception.OperationTimedoutException;
+import com.cloud.host.Host;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.Storage;
+import com.cloud.storage.StoragePool;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
+import com.cloud.utils.Pair;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataMotionStrategy;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class KVMStorageMotionStrategy  implements DataMotionStrategy {
+    private static final Logger s_logger = Logger.getLogger(KVMStorageMotionStrategy.class);
+    @Inject
+    AgentManager agentMgr;
+    @Inject
+    VolumeDao volDao;
+    @Inject
+    VolumeDataFactory volFactory;
+    @Inject
+    PrimaryDataStoreDao storagePoolDao;
+    @Inject
+    VMInstanceDao instanceDao;
+
+    @Override
+    public StrategyPriority canHandle(DataObject srcData, DataObject destData) {
+        return StrategyPriority.CANT_HANDLE;
+    }
+
+    @Override
+    public StrategyPriority canHandle(Map<VolumeInfo, DataStore> volumeMap, Host srcHost, Host destHost) {
+        if (srcHost.getHypervisorType() == Hypervisor.HypervisorType.KVM && destHost.getHypervisorType() == Hypervisor.HypervisorType.KVM) {
+            return StrategyPriority.HYPERVISOR;
+        }
+        return StrategyPriority.CANT_HANDLE;
+    }
+
+    @Override
+    public void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+        Answer answer = null;
+        String errMsg = null;
+        try {
+            VMInstanceVO instance = instanceDao.findById(vmTo.getId());
+            if (instance != null) {
+                answer = migrateVmWithVolumes(instance, vmTo, srcHost, destHost, volumeMap);
+            } else {
+                throw new CloudRuntimeException("Unsupported operation requested for moving data.");
+            }
+        } catch (Exception e) {
+            s_logger.error("copy failed", e);
+            errMsg = e.toString();
+        }
+
+        CopyCommandResult result = new CopyCommandResult(null, answer);
+        result.setResult(errMsg);
+        callback.complete(result);
+
+    }
+
+    private Answer migrateVmWithVolumes(VMInstanceVO vm, VirtualMachineTO to, Host srcHost, Host destHost, Map<VolumeInfo, DataStore> volumeToPool) throws AgentUnavailableException {
+
+        // Initiate migration of a virtual machine with it's volumes.
+        try {
+            List<Pair<VolumeTO, StorageFilerTO>> volumeToFilerTo = new ArrayList<Pair<VolumeTO, StorageFilerTO>>();
+            for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
+                VolumeInfo volume = entry.getKey();
+                VolumeTO volumeTo = new VolumeTO(volume, storagePoolDao.findById(volume.getPoolId()));
+                StorageFilerTO filerTo = new StorageFilerTO((StoragePool)entry.getValue());
+                volumeToFilerTo.add(new Pair<VolumeTO, StorageFilerTO>(volumeTo, filerTo));
+            }
+
+            MigrateWithStorageCommand command = new MigrateWithStorageCommand(to, volumeToFilerTo, destHost.getPrivateIpAddress());
+            MigrateWithStorageAnswer answer = (MigrateWithStorageAnswer) agentMgr.send(srcHost.getId(), command);
+            if (answer == null) {
+                s_logger.error("Migration with storage of vm " + vm + " failed.");
+                throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost);
+            } else if (!answer.getResult()) {
+                s_logger.error("Migration with storage of vm " + vm+ " failed. Details: " + answer.getDetails());
+                throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost +
+                        ". " + answer.getDetails());
+            } else {
+                // Update the volume details after migration.
+                updateVolumePathsAfterMigration(volumeToPool, answer.getVolumeTos());
+            }
+
+            return answer;
+        } catch (OperationTimedoutException e) {
+            s_logger.error("Error while migrating vm " + vm + " to host " + destHost, e);
+            throw new AgentUnavailableException("Operation timed out on storage motion for " + vm, destHost.getId());
+        }
+    }
+
+    private void updateVolumePathsAfterMigration(Map<VolumeInfo, DataStore> volumeToPool, List<VolumeObjectTO> volumeTos) {
+        for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
+            boolean updated = false;
+            VolumeInfo volume = entry.getKey();
+            StoragePool pool = (StoragePool)entry.getValue();
+            for (VolumeObjectTO volumeTo : volumeTos) {
+                if (volume.getId() == volumeTo.getId()) {
+                    VolumeVO volumeVO = volDao.findById(volume.getId());
+                    Long oldPoolId = volumeVO.getPoolId();
+                    volumeVO.setPath(volumeTo.getPath());
+                    volumeVO.setPodId(pool.getPodId());
+                    volumeVO.setPoolId(pool.getId());
+                    volumeVO.setLastPoolId(oldPoolId);
+                    // For SMB, pool credentials are also stored in the uri query string.  We trim the query string
+                    // part  here to make sure the credentials do not get stored in the db unencrypted.
+                    String folder = pool.getPath();
+                    // TODO to remove
+                    s_logger.debug("MARCO: folder path to check for credentials unencrypted: " + folder);
+//                    if (pool.getPoolType() == Storage.StoragePoolType.SMB && folder != null && folder.contains("?")) {
+//                        folder = folder.substring(0, folder.indexOf("?"));
+//                    }
+                    volumeVO.setFolder(folder);
+
+                    volDao.update(volume.getId(), volumeVO);
+                    updated = true;
+                    break;
+                }
+            }
+
+            if (!updated) {
+                s_logger.error("Volume path wasn't updated for volume " + volume + " after it was migrated.");
+            }
+        }
+    }
+}

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/motion/KVMStorageMotionStrategy.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/motion/KVMStorageMotionStrategy.java
@@ -12,7 +12,6 @@ import com.cloud.exception.AgentUnavailableException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.host.Host;
 import com.cloud.hypervisor.Hypervisor;
-import com.cloud.storage.Storage;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/storage/motion/KVMStorageMotionStrategy.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/storage/motion/KVMStorageMotionStrategy.java
@@ -1,4 +1,4 @@
-package com.cloud.hypervisor.kvm.storage.motion;
+package org.apache.cloudstack.storage.motion;
 
 
 import com.cloud.agent.AgentManager;

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/storage/motion/KVMStorageMotionStrategy.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/storage/motion/KVMStorageMotionStrategy.java
@@ -139,7 +139,6 @@ public class KVMStorageMotionStrategy  implements DataMotionStrategy {
                         ". " + provisioningAnwer.getDetails());
             }
 
-            // TODO clean up of provisioned disk in case of failure during the next step
             MigrateWithStorageCommand command = new MigrateWithStorageCommand(to, volumeToFilerTo, destHost.getPrivateIpAddress());
             MigrateWithStorageAnswer answer = (MigrateWithStorageAnswer) agentMgr.send(srcHost.getId(), command);
             if (answer == null) {

--- a/plugins/hypervisors/simulator/src/org/apache/cloudstack/storage/motion/SimulatorDataMotionStrategy.java
+++ b/plugins/hypervisors/simulator/src/org/apache/cloudstack/storage/motion/SimulatorDataMotionStrategy.java
@@ -43,21 +43,13 @@ public class SimulatorDataMotionStrategy implements DataMotionStrategy {
     }
 
     @Override
-    public Void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+    public void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Void copyAsync(DataObject srcData, DataObject destData, AsyncCompletionCallback<CopyCommandResult> callback) {
+    public void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         CopyCommandResult result = new CopyCommandResult("something", null);
         callback.complete(result);
-        return null;
-    }
-
-    @Override
-    public Void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
-        CopyCommandResult result = new CopyCommandResult("something", null);
-        callback.complete(result);
-        return null;
     }
 }

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1195,7 +1195,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                     }
                 }
             }
-            plan = new DataCenterDeployment(srcHost.getDataCenterId(), null, null, null, null, null);
+            plan = new DataCenterDeployment(srcHost.getDataCenterId(), srcHost.getPodId(), srcHost.getClusterId(), null, null, null);
         } else {
             Long cluster = srcHost.getClusterId();
             if (s_logger.isDebugEnabled()) {

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -4213,7 +4213,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         // Check if the source and destination hosts are of the same type and support storage motion.
-        if (!(srcHost.getHypervisorType().equals(destinationHost.getHypervisorType()) && srcHost.getHypervisorVersion().equals(destinationHost.getHypervisorVersion()))) {
+        if (!(srcHost.getHypervisorType().equals(destinationHost.getHypervisorType()) &&
+                ((srcHost.getHypervisorVersion() == null && destinationHost.getHypervisorVersion() == null) || (srcHost.getHypervisorVersion().equals(destinationHost.getHypervisorVersion()))))) {
             throw new CloudRuntimeException("The source and destination hosts are not of the same type and version. " + "Source hypervisor type and version: "
                     + srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: "
                     + destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -4272,7 +4272,13 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         HostVO destinationHostVO = _hostDao.findById(destinationHost.getId());
         if (_capacityMgr.checkIfHostReachMaxGuestLimit(destinationHostVO)) {
             throw new VirtualMachineMigrationException("Host name: " + destinationHost.getName() + ", hostId: " + destinationHost.getId()
-                    + " already has max running vms (count includes system VMs). Cannot" + " migrate to this host");
+                    + " already has max running vms (count includes system VMs). Cannot migrate to this host");
+        }
+
+        // Check if the destination host has enough space
+        if (!_storageMgr.storagePoolHasEnoughSpace(new ArrayList<Volume>(vmVolumes), (StoragePool)_dataStoreMgr.getDataStore(_storageMgr.findLocalStorageOnHost(destinationHost.getId()).getId(), DataStoreRole.Primary))) {
+            throw new VirtualMachineMigrationException("Host name: " + destinationHost.getName() + ", hostId: " + destinationHost.getId()
+                    + " does not have enough space on its storage pool. Cannot migrate to this host");
         }
 
         checkHostsDedication(vm, srcHostId, destinationHost.getId());


### PR DESCRIPTION
Modifications
==========
To achieve the live migration of VMs with non-shared storage, here is a list of things left to be done

Things left
---------------
- [x] Fix hypervisors names to match certificates (https://github.com/exoscale/puppet/pull/75, https://github.com/exoscale/puppet/pull/76, https://github.com/exoscale/puppet/pull/77, https://github.com/exoscale/puppet/pull/78, https://github.com/exoscale/puppet/pull/79, https://github.com/exoscale/puppet/pull/80, https://github.com/exoscale/puppet/pull/81, https://github.com/exoscale/puppet/pull/82, https://github.com/exoscale/puppet/pull/83, https://github.com/exoscale/puppet/pull/84)
- [ ] Fix libgcrypt for encryption support

Configuration changes
-------------------------------
- [ ] Change KVM hypervisor capabilities in the DB (activate `motion_storage`) ✍️
  - [x] preprod
  - [ ] prod, to do after ProdShip
- [x] Change configuration in puppet (see exoscale/puppet#66)
- [ ] Update libvirt on hypervisors to 1.2.21
  - [x] preprod, done manually
  - [ ] prod


Live migration steps
---------------------------
- [x] Unlock CS code to allow `MigrateWithStorage`command for KVM with non shared storage/local storage;
- [x] Check that base image is on the destination host or download it;
- [x] Pre-provisioning of the disk, based on the backing file on the destination host;
- [x] ~~Dump vm XML and change VNC address to the destination's one;~~ _already in CS_
- [x] Send command to libvirt to migrate the vm with flags `(1 << 0)|(1 << 1)|(1 << 2)|(1 << 7)|(1 << 8)|(1 << 12)|(1 << 13)` along with the patched XML description;
  - 0 = VIR_MIGRATE_LIVE - ok
  - 1 = VIR_MIGRATE_PEER2PEER
  - 2 = VIR_MIGRATE_TUNNELLED (to have TLS encryption)
  - 7 = VIR_MIGRATE_NON_SHARED_INC - ok
  - 8 = VIR_MIGRATE_CHANGE_PROTECTION - ok
  - 11 = VIR_MIGRATE_COMPRESSED - ok
  - 12 = VIR_MIGRATE_ABORT_ON_ERROR - ok
  - 13 = VIR_MIGRATE_AUTO_CONVERGE - ok
- [x] Remove vm's disk image file on the source host.


Nice to have
-----------------
When doing manual migration (on the host, through virsh command), the only missing thing is the auto discovery of. CS sees the VM on the new host thanks to the ping command of vms:
- [ ] Volume move of non-shared storage to the destination host;
- [ ] Network traffic should be redirected to the destination host.


Error handling
-------------------
- [x] On failed migration (like a vnc socket error), volume pool id stays with the destination value, state of the volume stays as Migrating. It should be reverted to the source host and to a state Ready;
- [x] Unsure about the IP/network routing update/rollback.
- [x] On migration failure, the VM is stopped
- [x] On migration failure, or success, the volume on the dest or src host is removed


Tests
--------
To be written with @vbernat pytests and added in jenkins as integration tests for cloudstack
- migrate VM while being logged in SSH
- migrate VM with high CPU load
- migrate VM with high IO load
- migrate VM with a few snapshots
  - try revert to previous snapshot
  - try to revert to a snapshot -x (with x > 2)
  - try to revert to 1st snapshot
- migrate Windows VM with a remote connection open
- migrate VM and verify security groups
- try to migrate VM on a host that should not be able to accept the VM (memory exhausted)
- to be continued
- force a failing migration (put a hook?) and validate `cleanup` method

Linked pull requests to commit
=======================
- https://github.com/exoscale/puppet/pull/66