### PR TITLE
kafka: prepare event bus for TLS

### DIFF
--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.8.2.0</version>
+      <version>0.9.0.1</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
We don't need much to switch Cloudstack to TLS, everything happens in the properties we feed to the kafka client when setting it up.