### PR TITLE
events: add accountName to action events

### DIFF
--- a/server/src/com/cloud/event/ActionEventUtils.java
+++ b/server/src/com/cloud/event/ActionEventUtils.java
@@ -231,6 +231,7 @@ public class ActionEventUtils {
             eventDescription.put("project", project.getUuid());
         eventDescription.put("user", user.getUuid());
         eventDescription.put("account", account.getUuid());
+        eventDescription.put("accountName", account.getAccountName());
         eventDescription.put("event", eventType);
         eventDescription.put("status", state.toString());
         eventDescription.put("entity", entityType);


### PR DESCRIPTION
The rationale is that we want an organization name to show up here.
In uri's `sanitizer` process we will then use this account name as a key for produced messages.
Right now entity UUIDs are used as keys which makes reconciliation a bit harder than necessary.

The corollary is that the URI `stream` consumer will eventually become  partitioned by organization, making emitting regular output per organization that much easier.
